### PR TITLE
Fix COM frequency reporting broken by 8.33 kHz float switch (#120)

### DIFF
--- a/JoinFS/WebSocketServer.cs
+++ b/JoinFS/WebSocketServer.cs
@@ -165,11 +165,7 @@ namespace JoinFS
             }
         }
 
-        static string FormatFreq(int raw)
-        {
-            string s = raw.ToString();
-            return s.Length < 3 ? "" : s[..3] + "." + s[3..];
-        }
+        static string FormatFreq(float value) => value == 0 ? "" : value.ToString("F3");
 
         AircraftSnapshot SnapshotFromAircraft(Sim.Aircraft aircraft)
         {
@@ -200,8 +196,14 @@ namespace JoinFS
 
             if (aircraft.variableSet != null)
             {
-                snap.com1   = FormatFreq(aircraft.variableSet.GetInteger(vuidCom1));
-                snap.com2   = FormatFreq(aircraft.variableSet.GetInteger(vuidCom2));
+                // Try Float first (8.33 kHz-capable), fall back to legacy BCD Integer
+                float com1Value = aircraft.variableSet.GetFloat(vuidCom1);
+                if (com1Value == 0) com1Value = aircraft.variableSet.GetInteger(vuidCom1) / 100f;
+                snap.com1 = FormatFreq(com1Value);
+
+                float com2Value = aircraft.variableSet.GetFloat(vuidCom2);
+                if (com2Value == 0) com2Value = aircraft.variableSet.GetInteger(vuidCom2) / 100f;
+                snap.com2 = FormatFreq(com2Value);
                 snap.squawk = aircraft.variableSet.GetInteger(vuidSquawk).ToString();
                 snap.gear   = aircraft.variableSet.GetInteger(vuidGear);
                 snap.flaps  = aircraft.variableSet.GetFloat(vuidFlaps);

--- a/JoinFS/WebhookService.cs
+++ b/JoinFS/WebhookService.cs
@@ -26,11 +26,7 @@ namespace JoinFS
             vuidCom2 = VariableMgr.CreateVuid("com active frequency:2");
         }
 
-        static string FormatFreq(int raw)
-        {
-            string s = raw.ToString();
-            return s.Length < 3 ? "" : s[..3] + "." + s[3..];
-        }
+        static string FormatFreq(float value) => value == 0 ? "" : value.ToString("F3");
 
         public void DoWork()
         {
@@ -49,8 +45,14 @@ namespace JoinFS
                     string com1 = "", com2 = "";
                     if (aircraft.variableSet != null)
                     {
-                        com1 = FormatFreq(aircraft.variableSet.GetInteger(vuidCom1));
-                        com2 = FormatFreq(aircraft.variableSet.GetInteger(vuidCom2));
+                        // Try Float first (8.33 kHz-capable), fall back to legacy BCD Integer
+                        float com1Value = aircraft.variableSet.GetFloat(vuidCom1);
+                        if (com1Value == 0) com1Value = aircraft.variableSet.GetInteger(vuidCom1) / 100f;
+                        com1 = FormatFreq(com1Value);
+
+                        float com2Value = aircraft.variableSet.GetFloat(vuidCom2);
+                        if (com2Value == 0) com2Value = aircraft.variableSet.GetInteger(vuidCom2) / 100f;
+                        com2 = FormatFreq(com2Value);
                     }
 
                     if (com1.Length == 0 && com2.Length == 0) continue;

--- a/JoinFS/Whazzup.cs
+++ b/JoinFS/Whazzup.cs
@@ -216,8 +216,10 @@ namespace JoinFS
                                 // get variables
                                 if (aircraft.variableSet != null)
                                 {
-                                    com1 = aircraft.variableSet.GetInteger(vuidCom1).ToString(CultureInfo.InvariantCulture);
-                                    com1 = (com1.Length < 4) ? "" : com1.Substring(0, 3) + "." + com1.Substring(3, 2);
+                                    // Try Float first (8.33 kHz-capable), fall back to legacy BCD Integer
+                                    float com1Value = aircraft.variableSet.GetFloat(vuidCom1);
+                                    if (com1Value == 0) com1Value = aircraft.variableSet.GetInteger(vuidCom1) / 100f;
+                                    if (com1Value != 0) com1 = com1Value.ToString("F3", CultureInfo.InvariantCulture);
                                     from = aircraft.variableSet.GetString8(vuidFrom);
                                     to = aircraft.variableSet.GetString8(vuidTo);
                                     squawk = aircraft.variableSet.GetInteger(vuidSquawk);


### PR DESCRIPTION
PR #120 changed COM ACTIVE FREQUENCY:1/2 from an INTEGER (BCD) variable to a FLOAT (MHz) variable to support 8.33 kHz channel spacing, but only AircraftForm.cs was updated to read it via GetFloat(). WebhookService.cs, WebSocketServer.cs, and Whazzup.cs still called GetInteger(), which now always returns 0 - collapsing to an empty frequency string and silently dropping affected aircraft from the webhook payload entirely (breaking TS channel-switching via tsapi) and from the WebSocket feed.

All three now mirror AircraftForm.cs: read GetFloat() first, fall back to GetInteger()/100f for legacy network peers still on the old BCD format, and format with "F3".

fixes #130 