### PR TITLE
Fix busy-loop pegging CPU in CONSOLE background mode

### DIFF
--- a/JoinFS/Program.cs
+++ b/JoinFS/Program.cs
@@ -115,6 +115,7 @@ namespace JoinFS
 
 #if CONSOLE
         public bool settingsBackground = false;
+        public int settingsBackgroundDelay = 100;
         public string settingsComsWebhookUri = "";
         public string settingsComsWebhookMethod = "PUT";
         public bool settingsWebSocket = false;
@@ -551,6 +552,20 @@ namespace JoinFS
                                 settingsBackground = true;
                                 break;
 
+                            case "-backgrounddelay":
+                                // next parameter
+                                index++;
+                                // check for parameter
+                                if (index < args.Length)
+                                {
+                                    if (int.TryParse(args[index], NumberStyles.Number, CultureInfo.InvariantCulture, out int delay))
+                                    {
+                                        // update background delay, never negative
+                                        settingsBackgroundDelay = Math.Max(0, delay);
+                                    }
+                                }
+                                break;
+
                             case "-comswebhookuri":
                                 index++;
                                 if (index < args.Length) settingsComsWebhookUri = args[index];
@@ -605,6 +620,7 @@ namespace JoinFS
                                 Console.WriteLine("  --whazzup-public       " + Resources.Strings.Tip_WhazzupGlobal);
                                 Console.WriteLine("  --minimize             " + Resources.Strings.Options_Minimize);
                                 Console.WriteLine("  --background           " + Resources.Strings.Options_Background);
+                                Console.WriteLine("  --backgrounddelay <ms> Idle delay of the --background shutdown poll (default 100, 0 to spin)");
                                 Console.WriteLine("  --nosim                " + Resources.Strings.Options_NoSim);
                                 Console.WriteLine("  --nogui                " + Resources.Strings.Options_NoGui);
                                 Console.WriteLine("  --multiobjects         " + Resources.Strings.Tip_MultiObjects);
@@ -2036,6 +2052,18 @@ namespace JoinFS
                         else if (info.Modifiers == ConsoleModifiers.Control && info.Key == ConsoleKey.N) main.ToggleNetwork();
                         else if (info.Modifiers == ConsoleModifiers.Control && info.Key == ConsoleKey.S) main.ToggleSimulator();
                         else if (info.Modifiers == ConsoleModifiers.Control && info.Key == ConsoleKey.Q) main.substitution ?. Scan(true);
+                    }
+                    else
+                    {
+                        // Background mode has no key input to block on, so without a sleep this
+                        // loop spins and pegs a CPU core (30% util down to 3% at the 100ms default).
+                        // Only shutdown responsiveness is affected - aircraft syncing runs on the
+                        // work thread (DoWork) at its own 5ms cadence and is not touched by this.
+                        // Use --backgrounddelay 0 to spin uninterrupted.
+                        if (main.settingsBackgroundDelay > 0)
+                        {
+                            Thread.Sleep(main.settingsBackgroundDelay);
+                        }
                     }
 #else
                     // sleep

--- a/JoinFS/libs/CONSOLE/Old-Readme.txt
+++ b/JoinFS/libs/CONSOLE/Old-Readme.txt
@@ -36,6 +36,7 @@ Usage: dotnet JoinFS-CONSOLE.dll [options]
   --whazzup-public       Include aircraft from all public hubs in the 'whazzup.txt' file
   --minimize             Launch JoinFS minimized on the Windows task bar. Quiet mode.
   --background           For JoinFS-CONSOLE, run as a background task with no keyboard input.
+  --backgrounddelay <ms> Idle delay for the --background shutdown poll (default 100). Use 0 to poll without sleeping, which costs a fully loaded CPU core. Aircraft syncing is unaffected either way - it runs on a separate work thread.
   --nosim                Do not connect to the simulator at launch.
   --nogui                Run JoinFS as a background process without any windows or UI.
   --multiobjects         Allow this client to receive more than one aircraft from any other client in a session.


### PR DESCRIPTION
### Problem
Running the CONSOLE build as a headless hub with `--background` uses
noticeably high CPU while idle (~30% in my setup, no pilots connected).

### Testing
Built the CONSOLE config as a Docker image and ran it as a hub via
`--hub --nosim --nogui --background`. Idle CPU dropped from ~30% to ~3%
(`docker stats`) with no pilots connected and no change in hub behavior.

