### PR TITLE
Fix SimBrief callsign being overwritten by sim/livery-derived guess

### DIFF
--- a/JoinFS/Sim.cs
+++ b/JoinFS/Sim.cs
@@ -3687,8 +3687,15 @@ namespace JoinFS
                                         string flightNumber = info.flightNumber.TrimStart(' ', '\t').TrimEnd(' ', '\t');
                                         aircraft.flightPlan.registration = tailNumber;
                                         aircraft.flightPlan.flightNumber = flightNumber;
-                                        // prefer a synthesized real callsign (ICAO airline + flight number) over the tail number
-                                        aircraft.flightPlan.callsign = ResolveCallsign(resolvedIcaoAirline, flightNumber, tailNumber);
+                                        // prefer a synthesized real callsign (ICAO airline + flight number) over the tail number,
+                                        // but only when not already set - a prior SimBrief-imported callsign must survive this
+                                        // aircraft being (re-)listed, matching the "userFlightPlan survives" intent above; without
+                                        // this guard the sim-reported ATC AIRLINE/FLIGHT NUMBER (aircraft.cfg/livery.cfg/MSFS2024
+                                        // aircraft customization) unconditionally clobbered the SimBrief callsign every time
+                                        if (aircraft.flightPlan.callsign.Length == 0)
+                                        {
+                                            aircraft.flightPlan.callsign = ResolveCallsign(resolvedIcaoAirline, flightNumber, tailNumber);
+                                        }
                                         // fill in ICAO type/airline from the live-resolved data (learnIcaoType/
                                         // resolvedIcaoAirline - see the confidence hierarchy above), but only when
                                         // not already set - this was never populated here at all before, leaving

--- a/Readmes/Release-26.5.md
+++ b/Readmes/Release-26.5.md
@@ -30,6 +30,7 @@
 - Fixed the Flight Plan dialog's callsign field being read-only - it's the one place to set/override a callsign now that the old context-menu override has been removed.
 - Pressing Enter in the SimBrief username field now saves the username and runs the import before closing the dialog, instead of closing immediately without saving anything.
 - Fixed the Flight Plan dialog's tab order (SimBrief username → Import → Clear → OK → Cancel), which had collided with the OK/Cancel buttons' tab indices.
+- **Fixed a SimBrief-imported callsign being overwritten by a sim/livery-derived guess (e.g. `DLH1234` reverting to `Lufthansa 320`).** Whenever the user's aircraft object was (re-)listed by the sim, its callsign was unconditionally re-derived from the aircraft's `ATC AIRLINE`/`ATC FLIGHT NUMBER` (aircraft.cfg/livery.cfg or MSFS2024 aircraft customization data), clobbering any callsign already fetched from SimBrief - regardless of fetch order. The sim-derived callsign is now only used as a fallback when no callsign is already set, matching how ICAO type/airline are already handled in the same code path.
 
 ## Limitations
 


### PR DESCRIPTION
The user's aircraft object's callsign was unconditionally re-derived from ATC AIRLINE/ATC FLIGHT NUMBER (aircraft.cfg/livery.cfg or MSFS2024 aircraft customization) every time it was (re-)listed by the sim, clobbering a callsign already imported from SimBrief regardless of fetch order. Guard it the same way icaoType/icaoAirline already are in this code path: only fall back to the sim-derived value when no callsign is set yet.

Fixes #156